### PR TITLE
Refactor message status handling in aggregates and tests

### DIFF
--- a/MessagingService.EmailAggregate.Tests/EmailAggregateTests.cs
+++ b/MessagingService.EmailAggregate.Tests/EmailAggregateTests.cs
@@ -85,7 +85,6 @@ namespace MessagingService.EmailAggregate.Tests
 
         [Theory]
         [InlineData(MessageStatus.NotSet)]
-        [InlineData(MessageStatus.Delivered)]
         [InlineData(MessageStatus.Rejected)]
         [InlineData(MessageStatus.Failed)]
         [InlineData(MessageStatus.Spam)]
@@ -139,7 +138,6 @@ namespace MessagingService.EmailAggregate.Tests
         [Theory]
         [InlineData(MessageStatus.NotSet)]
         [InlineData(MessageStatus.Delivered)]
-        [InlineData(MessageStatus.Rejected)]
         [InlineData(MessageStatus.Failed)]
         [InlineData(MessageStatus.Spam)]
         [InlineData(MessageStatus.Bounced)]
@@ -192,7 +190,6 @@ namespace MessagingService.EmailAggregate.Tests
         [InlineData(MessageStatus.NotSet)]
         [InlineData(MessageStatus.Delivered)]
         [InlineData(MessageStatus.Rejected)]
-        [InlineData(MessageStatus.Failed)]
         [InlineData(MessageStatus.Spam)]
         [InlineData(MessageStatus.Bounced)]
         public void EmailAggregate_MarkMessageAsFailed_IncorrectState_ErrorThrown(MessageStatus messageStatus) {
@@ -246,7 +243,6 @@ namespace MessagingService.EmailAggregate.Tests
         [InlineData(MessageStatus.Rejected)]
         [InlineData(MessageStatus.Failed)]
         [InlineData(MessageStatus.Spam)]
-        [InlineData(MessageStatus.Bounced)]
         public void EmailAggregate_MarkMessageAsBounced_IncorrectState_ErrorThrown(MessageStatus messageStatus) {
             EmailAggregate emailAggregate = EmailAggregate.Create(TestData.MessageId);
 
@@ -297,7 +293,6 @@ namespace MessagingService.EmailAggregate.Tests
         [InlineData(MessageStatus.Delivered)]
         [InlineData(MessageStatus.Rejected)]
         [InlineData(MessageStatus.Failed)]
-        [InlineData(MessageStatus.Spam)]
         [InlineData(MessageStatus.Bounced)]
         public void EmailAggregate_MarkMessageAsSpam_IncorrectState_ErrorThrown(MessageStatus messageStatus) {
             EmailAggregate emailAggregate = EmailAggregate.Create(TestData.MessageId);

--- a/MessagingService.EmailMessageAggregate/EmailAggregate.cs
+++ b/MessagingService.EmailMessageAggregate/EmailAggregate.cs
@@ -15,6 +15,8 @@
         public static void MarkMessageAsBounced(this EmailAggregate aggregate, String providerStatus,
                                          DateTime bouncedDateTime)
         {
+            if (aggregate.DeliveryStatusList[aggregate.ResendCount] == MessageStatus.Bounced)
+                return;
             aggregate.CheckMessageCanBeSetToBounced();
 
             EmailMessageBouncedEvent messageBouncedEvent = new EmailMessageBouncedEvent(aggregate.AggregateId, providerStatus, bouncedDateTime);
@@ -25,6 +27,8 @@
         public static void MarkMessageAsDelivered(this EmailAggregate aggregate, String providerStatus,
                                                   DateTime deliveredDateTime)
         {
+            if (aggregate.DeliveryStatusList[aggregate.ResendCount] == MessageStatus.Delivered)
+                return;
             aggregate.CheckMessageCanBeSetToDelivered();
 
             EmailMessageDeliveredEvent messageDeliveredEvent = new EmailMessageDeliveredEvent(aggregate.AggregateId, providerStatus, deliveredDateTime);
@@ -35,6 +39,8 @@
         public static void MarkMessageAsFailed(this EmailAggregate aggregate, String providerStatus,
                                         DateTime failedDateTime)
         {
+            if (aggregate.DeliveryStatusList[aggregate.ResendCount] == MessageStatus.Failed)
+                return;
             aggregate.CheckMessageCanBeSetToFailed();
 
             EmailMessageFailedEvent messageFailedEvent = new EmailMessageFailedEvent(aggregate.AggregateId, providerStatus, failedDateTime);
@@ -45,6 +51,8 @@
         public static void MarkMessageAsRejected(this EmailAggregate aggregate, String providerStatus,
                                           DateTime rejectedDateTime)
         {
+            if (aggregate.DeliveryStatusList[aggregate.ResendCount] == MessageStatus.Rejected)
+                return;
             aggregate.CheckMessageCanBeSetToRejected();
 
             EmailMessageRejectedEvent messageRejectedEvent = new EmailMessageRejectedEvent(aggregate.AggregateId, providerStatus, rejectedDateTime);
@@ -55,6 +63,8 @@
         public static void MarkMessageAsSpam(this EmailAggregate aggregate, String providerStatus,
                                       DateTime spamDateTime)
         {
+            if (aggregate.DeliveryStatusList[aggregate.ResendCount] == MessageStatus.Spam)
+                return;
             aggregate.CheckMessageCanBeSetToSpam();
 
             EmailMessageMarkedAsSpamEvent messageMarkedAsSpamEvent = new EmailMessageMarkedAsSpamEvent(aggregate.AggregateId, providerStatus, spamDateTime);

--- a/MessagingService.SMSAggregate.Tests/SMSAggregateTests.cs
+++ b/MessagingService.SMSAggregate.Tests/SMSAggregateTests.cs
@@ -62,7 +62,6 @@ namespace MessagingService.SMSAggregate.Tests
         [Theory]
         [InlineData(MessageStatus.NotSet)]
         [InlineData(MessageStatus.Expired)]
-        [InlineData(MessageStatus.Delivered)]
         [InlineData(MessageStatus.Undeliverable)]
         [InlineData(MessageStatus.InProgress)]
         [InlineData(MessageStatus.Rejected)]
@@ -117,7 +116,6 @@ namespace MessagingService.SMSAggregate.Tests
 
         [Theory]
         [InlineData(MessageStatus.NotSet)]
-        [InlineData(MessageStatus.Expired)]
         [InlineData(MessageStatus.Delivered)]
         [InlineData(MessageStatus.Undeliverable)]
         [InlineData(MessageStatus.InProgress)]
@@ -175,7 +173,6 @@ namespace MessagingService.SMSAggregate.Tests
         [InlineData(MessageStatus.NotSet)]
         [InlineData(MessageStatus.Expired)]
         [InlineData(MessageStatus.Delivered)]
-        [InlineData(MessageStatus.Undeliverable)]
         [InlineData(MessageStatus.InProgress)]
         [InlineData(MessageStatus.Rejected)]
         public void SMSAggregate_MarkMessageAsUndeliverable_IncorrectState_ErrorThrown(MessageStatus messageStatus)
@@ -233,7 +230,6 @@ namespace MessagingService.SMSAggregate.Tests
         [InlineData(MessageStatus.Delivered)]
         [InlineData(MessageStatus.Undeliverable)]
         [InlineData(MessageStatus.InProgress)]
-        [InlineData(MessageStatus.Rejected)]
         public void SMSAggregate_MarkMessageAsRejected_IncorrectState_ErrorThrown(MessageStatus messageStatus)
         {
             SMSAggregate smsAggregate = SMSAggregate.Create(TestData.MessageId);

--- a/MessagingService.SMSMessageAggregate/SMSAggregate.cs
+++ b/MessagingService.SMSMessageAggregate/SMSAggregate.cs
@@ -21,6 +21,9 @@
         public static void MarkMessageAsDelivered(this SMSAggregate aggregate,
                                                   String providerStatus,
                                                   DateTime failedDateTime){
+            if (aggregate.DeliveryStatusList[aggregate.ResendCount] == MessageStatus.Delivered)
+                return;
+
             aggregate.CheckMessageCanBeSetToDelivered();
 
             SMSMessageDeliveredEvent messageDeliveredEvent = new SMSMessageDeliveredEvent(aggregate.AggregateId, providerStatus, failedDateTime);
@@ -31,6 +34,8 @@
         public static void MarkMessageAsExpired(this SMSAggregate aggregate,
                                                 String providerStatus,
                                                 DateTime failedDateTime){
+            if (aggregate.DeliveryStatusList[aggregate.ResendCount] == MessageStatus.Expired)
+                return;
             aggregate.CheckMessageCanBeSetToExpired();
 
             SMSMessageExpiredEvent messageExpiredEvent = new SMSMessageExpiredEvent(aggregate.AggregateId, providerStatus, failedDateTime);
@@ -41,6 +46,8 @@
         public static void MarkMessageAsRejected(this SMSAggregate aggregate,
                                                  String providerStatus,
                                                  DateTime failedDateTime){
+            if (aggregate.DeliveryStatusList[aggregate.ResendCount] == MessageStatus.Rejected)
+                return;
             aggregate.CheckMessageCanBeSetToRejected();
 
             SMSMessageRejectedEvent messageRejectedEvent = new SMSMessageRejectedEvent(aggregate.AggregateId, providerStatus, failedDateTime);
@@ -51,6 +58,8 @@
         public static void MarkMessageAsUndeliverable(this SMSAggregate aggregate,
                                                       String providerStatus,
                                                       DateTime failedDateTime){
+            if (aggregate.DeliveryStatusList[aggregate.ResendCount] == MessageStatus.Undeliverable)
+                return;
             aggregate.CheckMessageCanBeSetToUndeliverable();
 
             SMSMessageUndeliveredEvent messageUndeliveredEvent = new SMSMessageUndeliveredEvent(aggregate.AggregateId, providerStatus, failedDateTime);
@@ -120,7 +129,7 @@
             aggregate.ApplyAndAppend(requestSentToProviderEvent);
         }
 
-        private static void CheckMessageCanBeSetToDelivered(this SMSAggregate aggregate){
+        private static void CheckMessageCanBeSetToDelivered(this SMSAggregate aggregate) {
             if (aggregate.DeliveryStatusList[aggregate.ResendCount] != MessageStatus.Sent){
                 throw new InvalidOperationException($"Message at status {aggregate.DeliveryStatusList[aggregate.ResendCount]} cannot be set to delivered");
             }


### PR DESCRIPTION
- Removed `InlineData` for certain `MessageStatus` values in `EmailAggregateTests.cs` and `SMSAggregateTests.cs` to narrow test cases.
- Added checks in `EmailAggregate.cs` and `SMSAggregate.cs` to prevent setting the same `MessageStatus` multiple times, enhancing state management.
- Minor formatting adjustment in `SMSAggregate.cs` for improved readability.